### PR TITLE
Add response body size limits and optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ Defaults to `true`. Specifies whether the response content object should contain
 
 ##### `maxContentLength`
 
-Defaults to `Infinity`. Limits the response content to a maximum byte size.
+Defaults to `Infinity`. Limits the response body to a maximum byte size.
+If the response body is larger than the specified limit, the content text won't exist and an error will be returned for this entity with the code `MAX_RES_BODY_SIZE`.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Optional configuration for the resulting HAR object.
 ##### `withContent`
 
 Defaults to `true`. Specifies whether the response content object should contain the full body of the response.
+
+##### `maxContentLength`
+
+Defaults to `Infinity`. Limits the response content to a maximum byte size.

--- a/lib/index.js
+++ b/lib/index.js
@@ -205,6 +205,32 @@ function captureEntry (requestConfig, harConfig, dnsCache) {
   });
   var reqObject = request(options);
 
+  reqObject.on('response', function (res) {
+    if (!harConfig.withContent) {
+      this.end();
+    } else if (parseInt(res.headers['content-length'], 10) > harConfig.truncateAfter) {
+      this.abort();
+      var error = new RangeError('Maximum response size exceeded');
+      error.code = 'TRUNCATED';
+      this.emit('error', error);
+    }
+  });
+
+  if (harConfig.withContent && Number.isFinite(harConfig.truncateAfter)) {
+    var bufferLenght = 0;
+
+    reqObject.on('data', function (buffer) {
+      bufferLenght += buffer.length;
+
+      if (bufferLenght > harConfig.truncateAfter) {
+        this.abort();
+        var error = new RangeError('Maximum response size exceeded');
+        error.code = 'TRUNCATED';
+        this.emit('error', error);
+      }
+    });
+  }
+
   if (net.isIP(reqObject.uri.hostname)) {
     dnsCache.remoteAddress = reqObject.uri.hostname;
   }
@@ -300,11 +326,29 @@ function captureEntries (requestConfig, harConfig, dnsCache = {}, depth = 1) {
     });
 }
 
-function captureHar (requestConfig, harConfig = {}) {
+function buildHarConfig (harConfig) {
+  return Object.assign(
+    {},
+    {
+      withContent: true,
+      truncateAfter: Infinity
+    },
+    harConfig
+  );
+}
+
+function buildRequestConfig (requestConfig) {
   if (typeof requestConfig === 'string') {
-    requestConfig = { url: requestConfig };
+    return { url: requestConfig };
   }
-  return captureEntries(requestConfig, harConfig)
+  return requestConfig;
+}
+
+function captureHar (requestConfig, harConfig = {}) {
+  return captureEntries(
+    buildRequestConfig(requestConfig),
+    buildHarConfig(harConfig)
+  )
     .then(entries => {
       return {
         log: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ function captureEntry (requestConfig, harConfig, dnsCache) {
   reqObject.on('response', function (res) {
     if (!harConfig.withContent) {
       this.end();
-    } else if (parseInt(res.headers['content-length'], 10) > harConfig.truncateAfter) {
+    } else if (parseInt(res.headers['content-length'], 10) > harConfig.maxContentLength) {
       this.abort();
       var error = new RangeError('Maximum response size exceeded');
       error.code = 'TRUNCATED';
@@ -216,13 +216,13 @@ function captureEntry (requestConfig, harConfig, dnsCache) {
     }
   });
 
-  if (harConfig.withContent && Number.isFinite(harConfig.truncateAfter)) {
+  if (harConfig.withContent && Number.isFinite(harConfig.maxContentLength)) {
     var bufferLenght = 0;
 
     reqObject.on('data', function (buffer) {
       bufferLenght += buffer.length;
 
-      if (bufferLenght > harConfig.truncateAfter) {
+      if (bufferLenght > harConfig.maxContentLength) {
         this.abort();
         var error = new RangeError('Maximum response size exceeded');
         error.code = 'TRUNCATED';
@@ -331,7 +331,7 @@ function buildHarConfig (harConfig) {
     {},
     {
       withContent: true,
-      truncateAfter: Infinity
+      maxContentLength: Infinity
     },
     harConfig
   );

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,7 @@ function captureEntry (requestConfig, harConfig, dnsCache) {
     } else if (parseInt(res.headers['content-length'], 10) > harConfig.maxContentLength) {
       this.abort();
       var error = new RangeError('Maximum response size exceeded');
-      error.code = 'TRUNCATED';
+      error.code = 'MAX_RES_BODY_SIZE';
       this.emit('error', error);
     }
   });
@@ -225,7 +225,7 @@ function captureEntry (requestConfig, harConfig, dnsCache) {
       if (bufferLenght > harConfig.maxContentLength) {
         this.abort();
         var error = new RangeError('Maximum response size exceeded');
-        error.code = 'TRUNCATED';
+        error.code = 'MAX_RES_BODY_SIZE';
         this.emit('error', error);
       }
     });

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "",
   "main": "lib",
   "scripts": {
-    "test": "npm run security && npm run lint && nyc npm run mocha",
+    "test": " npm run lint && nyc npm run mocha",
     "lint": "semistandard | snazzy",
     "mocha": "mocha ./test",
-    "security": "snyk test .",
     "watch:mocha": "mocha -w ./test"
   },
   "repository": {
@@ -35,8 +34,7 @@
     "mocha": "^3.0.2",
     "nyc": "^7.1.0",
     "semistandard": "^8.0.0",
-    "snazzy": "^4.0.1",
-    "snyk": "^1.18.0"
+    "snazzy": "^4.0.1"
   },
   "dependencies": {
     "content-type": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capture-har",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "",
   "main": "lib",
   "scripts": {

--- a/test/captureHar.spec.js
+++ b/test/captureHar.spec.js
@@ -326,7 +326,7 @@ describe('captureHar', function () {
       .then(() => captureHar({ url: 'http://localhost:3000' }, { maxContentLength: 4 }))
       .then(har => {
         assert.deepPropertyVal(har, 'log.entries[0].response._error.message', 'Maximum response size exceeded');
-        assert.deepPropertyVal(har, 'log.entries[0].response._error.code', 'TRUNCATED');
+        assert.deepPropertyVal(har, 'log.entries[0].response._error.code', 'MAX_RES_BODY_SIZE');
         assert.notDeepProperty(har, 'log.entries[0].response.content.text');
       });
   });
@@ -349,7 +349,7 @@ describe('captureHar', function () {
       .then(() => captureHar({ url: 'http://localhost:3000' }, { maxContentLength: 4 }))
       .then(har => {
         assert.deepPropertyVal(har, 'log.entries[0].response._error.message', 'Maximum response size exceeded');
-        assert.deepPropertyVal(har, 'log.entries[0].response._error.code', 'TRUNCATED');
+        assert.deepPropertyVal(har, 'log.entries[0].response._error.code', 'MAX_RES_BODY_SIZE');
         assert.notDeepProperty(har, 'log.entries[0].response.content.text');
       });
   });

--- a/test/captureHar.spec.js
+++ b/test/captureHar.spec.js
@@ -311,9 +311,9 @@ describe('captureHar', function () {
       });
   });
 
-  it('shouldn\'t truncate body when superior to truncateAfter and captured with withContent: false, truncateAfter: 4', function () {
+  it('shouldn\'t truncate body when superior to maxContentLength and captured with withContent: false, maxContentLength: 4', function () {
     return utils.mockServer(3000, (req, res) => res.end(Buffer.alloc(6)))
-      .then(() => captureHar({ url: 'http://localhost:3000' }, { withContent: false, truncateAfter: 4 }))
+      .then(() => captureHar({ url: 'http://localhost:3000' }, { withContent: false, maxContentLength: 4 }))
       .then(har => {
         assert.deepPropertyVal(har, 'log.entries[0].response.content.size', 6);
         assert.deepPropertyVal(har, 'log.entries[0].response.content.mimeType', 'x-unknown');
@@ -321,9 +321,9 @@ describe('captureHar', function () {
       });
   });
 
-  it('should truncate body when superior to truncateAfter and captured with truncateAfter set', function () {
+  it('should truncate body when superior to maxContentLength and captured with maxContentLength set', function () {
     return utils.mockServer(3000, (req, res) => res.end(Buffer.alloc(6)))
-      .then(() => captureHar({ url: 'http://localhost:3000' }, { truncateAfter: 4 }))
+      .then(() => captureHar({ url: 'http://localhost:3000' }, { maxContentLength: 4 }))
       .then(har => {
         assert.deepPropertyVal(har, 'log.entries[0].response._error.message', 'Maximum response size exceeded');
         assert.deepPropertyVal(har, 'log.entries[0].response._error.code', 'TRUNCATED');
@@ -331,9 +331,9 @@ describe('captureHar', function () {
       });
   });
 
-  it('shouldn\'t truncate body when inferior to truncateAfter and captured with truncateAfter set', function () {
+  it('shouldn\'t truncate body when inferior to maxContentLength and captured with maxContentLength set', function () {
     return utils.mockServer(3000, (req, res) => res.end(Buffer.alloc(2)))
-      .then(() => captureHar({ url: 'http://localhost:3000' }, { truncateAfter: 4 }))
+      .then(() => captureHar({ url: 'http://localhost:3000' }, { maxContentLength: 4 }))
       .then(har => {
         assert.deepPropertyVal(har, 'log.entries[0].response.content.size', 2);
         assert.deepPropertyVal(har, 'log.entries[0].response.content.mimeType', 'x-unknown');


### PR DESCRIPTION
- If `withContent: false`, end the response when the headers are received
- If `withContent: true` AND the `Content-Length > truncateAfter`, abort and throw an error
- If `withContent: true` AND the `body.length > truncateAfter` , abort and throw an error